### PR TITLE
Adding a switch to properly set the OStype on a VM creation.

### DIFF
--- a/Set-Vm.ps1
+++ b/Set-Vm.ps1
@@ -48,7 +48,7 @@ foreach($descr in $VmSettings) {
   Write-Host "Starting job to create a VM named $vmName"
 
   $jobs += $lab | New-AzDtlVm -VmName $vmName -Size $descr.size -StorageType $descr.storageType -CustomImage $imageName -Notes $descr.description `
-          -AsJob
+          -OsType $descr.osType -AsJob
 
   Start-Sleep -Seconds 60
 }


### PR DESCRIPTION
Hi, 
I've been using this project to set up Labs using both Linux and Windows machines and I noticed only Windows machine where exposed to the outside world through the load balancer.
I found the issue and though this could be shared.
The "New-AzDtlVm" method was not taking into account the current VM OS, and was always defaulting to Windows.

Keep up the great work, this project saved me a lot a time !

